### PR TITLE
Fix renewal service return type declaration

### DIFF
--- a/src/Services/Interfaces/RenewalServiceInterface.php
+++ b/src/Services/Interfaces/RenewalServiceInterface.php
@@ -6,7 +6,7 @@ interface RenewalServiceInterface
 {
     public function scheduleRenewalCheck(): void;
     public function processRenewals(): void;
-    public function processSingleRenewal(object $subscription): void;
+    public function processSingleRenewal(object $subscription): bool;
     public function retryFailedPayments(): void;
     public function cancelSubscription(int $subscription_id): bool;
     public function suspendSubscription(int $subscription_id): bool;


### PR DESCRIPTION
Align `processSingleRenewal` return type in `RenewalServiceInterface` to `bool` to fix a fatal signature mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-c345c250-fe00-4ad7-a326-9307b3d33da7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c345c250-fe00-4ad7-a326-9307b3d33da7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

