### PR TITLE
Fix woocommerce blocks payment issue

### DIFF
--- a/iyzico-subscription.php
+++ b/iyzico-subscription.php
@@ -140,13 +140,14 @@ use Iyzico\IyzipayWoocommerceSubscription\Admin\Settings;
     add_action(
         'before_woocommerce_init',
         function () {
-            if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+            if (class_exists('\\Automattic\\WooCommerce\\Utilities\\FeaturesUtil')) {
                 /**
                  * Skip WC class check.
                  *
                  * @psalm-suppress UndefinedClass
                  */
                 \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+                \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
             }
         }
     );

--- a/src/Services/HookService.php
+++ b/src/Services/HookService.php
@@ -73,6 +73,10 @@ class HookService implements HookServiceInterface
         
         // WooCommerce Blocks desteği
         add_action('woocommerce_blocks_loaded', [$this->pluginService, 'addWooCommerceBlocksSupport']);
+        // Eğer Blocks zaten yüklendiyse veya sınıf mevcutsa hemen kaydet
+        if (class_exists('Automattic\\WooCommerce\\Blocks\\Payments\\Integrations\\AbstractPaymentMethodType')) {
+            $this->pluginService->addWooCommerceBlocksSupport();
+        }
     }
 
     public function registerAdminHooks(): void

--- a/src/Services/PluginService.php
+++ b/src/Services/PluginService.php
@@ -27,14 +27,20 @@ class PluginService implements PluginServiceInterface
 
     public function addWooCommerceBlocksSupport(): void
     {
-        if (class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
-            require_once plugin_dir_path(__FILE__) . '../Gateway/IyzicoBlocksSupport.php';
-            add_action(
-                'woocommerce_blocks_payment_method_type_registration',
-                function(\Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) {
+        // Always register to the payment method type registration hook; Blocks will call this when ready
+        add_action(
+            'woocommerce_blocks_payment_method_type_registration',
+            function($payment_method_registry) {
+                if (! class_exists('Automattic\\WooCommerce\\Blocks\\Payments\\Integrations\\AbstractPaymentMethodType')) {
+                    return;
+                }
+                if (! class_exists('Iyzico\\IyzipayWoocommerceSubscription\\Gateway\\IyzicoBlocksSupport')) {
+                    require_once plugin_dir_path(__FILE__) . '../Gateway/IyzicoBlocksSupport.php';
+                }
+                if ($payment_method_registry instanceof \Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry) {
                     $payment_method_registry->register(new \Iyzico\IyzipayWoocommerceSubscription\Gateway\IyzicoBlocksSupport());
                 }
-            );
-        }
+            }
+        );
     }
 }


### PR DESCRIPTION
Enable Iyzico Subscription payment method for WooCommerce Blocks checkout. This resolves the "No payment method available" error by ensuring proper Blocks compatibility, gateway registration, and availability checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-c56a0a7a-75f5-498c-b054-68b72375e289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c56a0a7a-75f5-498c-b054-68b72375e289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

