### PR TITLE
Fix duplicate iyzico subscription registration

### DIFF
--- a/src/Services/HookService.php
+++ b/src/Services/HookService.php
@@ -71,12 +71,8 @@ class HookService implements HookServiceInterface
         // Ödeme işlemleri
         add_filter('woocommerce_payment_gateways', [$this->pluginService, 'addIyzicoGateway']);
         
-        // WooCommerce Blocks desteği
-        add_action('woocommerce_blocks_loaded', [$this->pluginService, 'addWooCommerceBlocksSupport']);
-        // Eğer Blocks zaten yüklendiyse veya sınıf mevcutsa hemen kaydet
-        if (class_exists('Automattic\\WooCommerce\\Blocks\\Payments\\Integrations\\AbstractPaymentMethodType')) {
-            $this->pluginService->addWooCommerceBlocksSupport();
-        }
+        // WooCommerce Blocks desteği - tek seferlik kayıt
+        $this->pluginService->addWooCommerceBlocksSupport();
     }
 
     public function registerAdminHooks(): void

--- a/src/Services/PluginService.php
+++ b/src/Services/PluginService.php
@@ -27,20 +27,23 @@ class PluginService implements PluginServiceInterface
 
     public function addWooCommerceBlocksSupport(): void
     {
+        static $blocksSupportHookAdded = false;
+        if ($blocksSupportHookAdded) {
+            return;
+        }
+        $blocksSupportHookAdded = true;
+
         // Always register to the payment method type registration hook; Blocks will call this when ready
-        add_action(
-            'woocommerce_blocks_payment_method_type_registration',
-            function($payment_method_registry) {
-                if (! class_exists('Automattic\\WooCommerce\\Blocks\\Payments\\Integrations\\AbstractPaymentMethodType')) {
-                    return;
-                }
-                if (! class_exists('Iyzico\\IyzipayWoocommerceSubscription\\Gateway\\IyzicoBlocksSupport')) {
-                    require_once plugin_dir_path(__FILE__) . '../Gateway/IyzicoBlocksSupport.php';
-                }
-                if ($payment_method_registry instanceof \Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry) {
-                    $payment_method_registry->register(new \Iyzico\IyzipayWoocommerceSubscription\Gateway\IyzicoBlocksSupport());
-                }
+        add_action('woocommerce_blocks_payment_method_type_registration', function ($payment_method_registry) {
+            if (! class_exists('Automattic\\WooCommerce\\Blocks\\Payments\\Integrations\\AbstractPaymentMethodType')) {
+                return;
             }
-        );
+            if (! class_exists('Iyzico\\IyzipayWoocommerceSubscription\\Gateway\\IyzicoBlocksSupport')) {
+                require_once plugin_dir_path(__FILE__) . '../Gateway/IyzicoBlocksSupport.php';
+            }
+            if ($payment_method_registry instanceof \Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry) {
+                $payment_method_registry->register(new \Iyzico\IyzipayWoocommerceSubscription\Gateway\IyzicoBlocksSupport());
+            }
+        });
     }
 }


### PR DESCRIPTION
Fixes duplicate WooCommerce Blocks integration registration to prevent "already registered" notices.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f078d90-b96f-4b92-a2f4-7f89de8922d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f078d90-b96f-4b92-a2f4-7f89de8922d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

